### PR TITLE
Add FujiNet support to FastBASIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,6 +369,7 @@ COMPILER_COMMON=\
 	 build/compiler/syntax/gr-a5200.syn\
 	 build/compiler/syntax/pm.syn\
 	 build/compiler/syntax/sound.syn\
+	 build/compiler/syntax/a800.syn\
 	 build/compiler/a5200.tgt\
 	 build/compiler/a800.tgt\
 	 build/compiler/atari-5200.tgt\

--- a/Makefile
+++ b/Makefile
@@ -580,6 +580,7 @@ SYNTAX_INT=\
 	src/syntax/pm.syn\
 	src/syntax/graphics.syn\
 	src/syntax/sound.syn\
+	src/syntax/sio.syn\
 
 # Syntax files for floating-point version
 SYNTAX_FP=\

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ SAMPLE_INT_BAS=\
     int/pi.bas \
     int/pmtest.bas \
     int/sieve.bas \
+    int/nc.bas \
 
 SAMPLE_BAS=$(SAMPLE_INT_BAS) $(SAMPLE_FP_BAS)
 SAMPLE_X_BAS=$(SAMPLE_FP_BAS:fp/%=%) $(SAMPLE_INT_BAS:int/%=%)

--- a/Makefile
+++ b/Makefile
@@ -370,6 +370,8 @@ COMPILER_COMMON=\
 	 build/compiler/syntax/pm.syn\
 	 build/compiler/syntax/sound.syn\
 	 build/compiler/syntax/a800.syn\
+	 build/compiler/syntax/sio.syn\
+	 build/compiler/syntax/fujinet.syn\
 	 build/compiler/a5200.tgt\
 	 build/compiler/a800.tgt\
 	 build/compiler/atari-5200.tgt\
@@ -582,6 +584,7 @@ SYNTAX_INT=\
 	src/syntax/graphics.syn\
 	src/syntax/sound.syn\
 	src/syntax/sio.syn\
+	src/syntax/fujinet.syn\
 
 # Syntax files for floating-point version
 SYNTAX_FP=\

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ CC=gcc
 # Optimization flags, added to C and C++ compiler flags
 OPTFLAGS=-O2
 
+# General options for C++ compiler
+CXXFLAG=-Wall -std=c++14
+
 # General flags for 6502 assembly files
 CA65_FLAGS=-g -tatari -I cc65/asminc -I src
 
@@ -54,12 +57,12 @@ CC65_CFLAGS=-Icc65/common -DBUILD_ID="fastbasic-$(VERSION)"
 
 # Flags for local tools needed to generate target files
 HOST_OPTFLAGS=$(OPTFLAGS)
-HOST_CXXFLAGS=-Wall -DVERSION=\"$(VERSION)\" $(HOST_OPTFLAGS)
+HOST_CXXFLAGS=$(CXXFLAGS) -DVERSION=\"$(VERSION)\" $(HOST_OPTFLAGS)
 HOST_CFLAGS=-Wall $(HOST_OPTFLAGS)
 
 # Flags for cross-compilation, could differ from host tools:
 TARGET_OPTFLAGS=$(OPTFLAGS)
-TARGET_CXXFLAGS=-Wall -DVERSION=\"$(VERSION)\" $(TARGET_OPTFLAGS)
+TARGET_CXXFLAGS=$(CXXFLAGS) -DVERSION=\"$(VERSION)\" $(TARGET_OPTFLAGS)
 TARGET_CFLAGS=-Wall $(TARGET_OPTFLAGS)
 
 # By default use quiet build

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ SAMPLE_INT_BAS=\
     int/pmtest.bas \
     int/sieve.bas \
     int/nc.bas \
+    int/mastodon.bas \
 
 SAMPLE_BAS=$(SAMPLE_INT_BAS) $(SAMPLE_FP_BAS)
 SAMPLE_X_BAS=$(SAMPLE_FP_BAS:fp/%=%) $(SAMPLE_INT_BAS:int/%=%)

--- a/compiler/a800.tgt
+++ b/compiler/a800.tgt
@@ -1,5 +1,5 @@
 # Atari 8-bit computers, base file
-syntax a800.syn basic.syn dli.syn fileio.syn pm.syn graphics.syn sound.syn extended.syn
+syntax a800.syn basic.syn dli.syn fileio.syn pm.syn graphics.syn sound.syn extended.syn sio.syn
 config fastbasic.cfg
 ca65 -tatari
 library fastbasic-int.lib

--- a/compiler/a800.tgt
+++ b/compiler/a800.tgt
@@ -1,5 +1,5 @@
 # Atari 8-bit computers, base file
-syntax a800.syn basic.syn dli.syn fileio.syn pm.syn graphics.syn sound.syn extended.syn sio.syn
+syntax a800.syn basic.syn dli.syn fileio.syn pm.syn graphics.syn sound.syn extended.syn sio.syn fujinet.syn
 config fastbasic.cfg
 ca65 -tatari
 library fastbasic-int.lib

--- a/samples/int/mastodon.bas
+++ b/samples/int/mastodon.bas
@@ -1,0 +1,108 @@
+' A Mastodon Client in FastBASIC
+
+' N: Unit to use
+unit=8
+
+' URL to Mastodon Server
+url$="N:HTTPS://oldbytes.space/api/v1/timelines/public?limit=1"$9B
+
+' QUERY string
+query$=""
+
+' QUERY result
+DIM result(1024) BYTE
+
+' JSON channel mode
+JSON_MODE=1
+
+' PROCEDURES '''''''''''''''''''''''''
+
+PROC nprinterror
+   NSTATUS unit
+   PRINT "ERROR- ";PEEK($02ED)
+ENDPROC
+
+PROC nsetchannelmode mode
+   SIO $71, unit, $FC, $00, 0, $1F, 0, 12, JSON_MODE
+ENDPROC
+
+PROC nparsejson
+   SIO $71, unit, $50, $00, 0, $1f, 0, 12, 0
+ENDPROC
+
+PROC njsonquery
+   SIO $71, unit, $51, $80, &query$+1, $1f, 256, 12, 0 
+ENDPROC
+
+PROC showresult
+   @njsonquery
+   NSTATUS unit
+
+   IF PEEK($02ED) > 128
+      PRINT "Could not fetch query:"
+      PRINT query$
+      EXIT
+   ENDIF
+
+   BW=DPEEK($02EA)
+   NGET unit,&result,BW
+   BPUT #0,&result,BW
+ENDPROC
+
+PROC mastodon
+     ' Open connection
+     NOPEN unit, 12, 0, url$
+
+     ' If not successful, then exit.
+     IF SErr()<>1
+     	PRINT "Could not open connection."
+        @nprinterror
+	EXIT
+     ENDIF
+
+     ' Change channel mode to JSON
+     @nsetchannelmode JSON_MODE
+
+     ' Ask FujiNet to parse JSON
+     @nparsejson
+
+     ' If not successful, then exit.
+     IF SErr()<>1
+       PRINT "Could not parse JSON."
+       @nprinterror
+       EXIT
+     ENDIF
+
+     ' Show latest post
+     query$="N:/0/account/display_name"$9B
+     @showresult
+     query$="N:/0/created_at"$9B
+     @showresult
+     query$="N:/0/content"$9B 
+     @showresult
+
+     NCLOSE unit
+
+     PRINT "" 
+     PRINT " ---- "
+     PRINT ""
+
+ENDPROC
+
+PROC waitabit
+     TIMER
+     DO 
+        IF TIME > 1800
+           EXIT
+        ENDIF
+     LOOP
+ENDPROC
+
+' MAIN PROGRAM '''''''''''''''''''''''
+
+DO
+
+  @mastodon
+  @waitabit
+
+LOOP

--- a/samples/int/nc.bas
+++ b/samples/int/nc.bas
@@ -1,0 +1,121 @@
+' -- #FUJINET NETCAT Example --
+
+' Default unit # for connection
+CONN=2
+MODE=12
+TRANS=0
+
+' URL for connection
+URL$=""
+
+' RX Buffer
+DIM BUF(8192) BYTE
+
+' Procedures '''''''''''''''''''''''''
+
+PROC BANNER
+
+PRINT "** NETCAT IN FASTBASIC **"$9B
+ENDPROC
+
+PROC GETCONN
+  DO 
+
+    INPUT "URL: ",URL$
+
+    C$=URL$[1,2]
+
+    IF C$="N:"
+      EXIT
+    ENDIF 
+
+  LOOP
+
+  INPUT "TRANS (0=none, 1=CR, 2=LF, 3=CR/LF): ",TRANS
+  
+ENDPROC
+
+PROC INTCLR
+  POKE $D302, PEEK($D302) & 127
+ENDPROC
+
+PROC CONNECT
+
+  PRINT "Connecting to:"
+  PRINT URL$
+
+  NOPEN CONN,MODE,TRANS,URL$
+  @INTCLR
+  NSTATUS CONN
+  
+ENDPROC
+
+PROC IN
+  NSTATUS CONN
+  BW = DPEEK($02EA)
+
+  IF BW = 0
+    EXIT
+  ENDIF
+
+  IF BW > 8192
+    BW = 8192
+  ENDIF 
+
+  NGET CONN,&BUF,BW
+  
+  FOR I=0 TO BW-1
+    PRINT CHR$(BUF(I));
+  NEXT I
+  
+ENDPROC
+
+PROC OUT
+  GET K
+  NPUT CONN,&K,1
+  POKE $2FC,255
+ENDPROC
+
+PROC NC
+
+  DO
+
+    IF PEEK($D302) & 128
+      @IN
+      @INTCLR
+    ENDIF
+    
+    IF PEEK($02EC) = 0
+      PRINT "Disconnected."
+      NCLOSE CONN
+      EXIT
+    ENDIF
+
+    IF PEEK($02FC) <> 255
+      @OUT
+    ENDIF
+    
+  LOOP
+
+ENDPROC
+
+' Main Program '''''''''''''''''''''''
+
+POKE 65,0
+
+@BANNER
+@GETCONN
+@CONNECT
+
+IF SErr() <> 1
+  NSTATUS CONN
+  PRINT "Could not Make Connection"
+  PRINT "ERROR- ";PEEK($02ED)
+  NCLOSE CONN
+ELSE
+  PRINT "Connected!"
+  @NC
+ENDIF
+
+POKE 65,3
+

--- a/src/syntax/fujinet.syn
+++ b/src/syntax/fujinet.syn
@@ -54,7 +54,7 @@ STATEMENT:
          "NGet" EXPR emit { TOK_NUM_POKE, &$301 } \
 	    ","      emit { TOK_NUM, &$304, TOK_SADDR } EXPR emit { TOK_DPOKE } \
 	    ","      emit { TOK_NUM, &$308, TOK_SADDR } EXPR emit { TOK_DPOKE } \
-	             emit { TOK_NUM, &$30A, TOK_SADDR TOK_NUM, &$308, TOK_DPEEK, TOK_DPOKE } \
+	             emit { TOK_NUM, &$30A, TOK_SADDR, TOK_NUM, &$308, TOK_DPEEK, TOK_DPOKE } \
 	             emit { TOK_BYTE, $71, TOK_NUM_POKE, &$0300 } \
 		     emit { TOK_BYTE, $52, TOK_NUM_POKE, &$0302 } \
 		     emit { TOK_BYTE, $40, TOK_NUM_POKE, &$0303 } \
@@ -64,7 +64,7 @@ STATEMENT:
          "NPut" EXPR emit { TOK_NUM_POKE, &$301 } \
 	    ","      emit { TOK_NUM, &$304, TOK_SADDR } EXPR emit { TOK_DPOKE } \
 	    ","      emit { TOK_NUM, &$308, TOK_SADDR } EXPR emit { TOK_DPOKE } \
-	             emit { TOK_NUM, &$30A, TOK_SADDR TOK_NUM, &$308, TOK_DPEEK, TOK_DPOKE } \
+	             emit { TOK_NUM, &$30A, TOK_SADDR, TOK_NUM, &$308, TOK_DPEEK, TOK_DPOKE } \
 	             emit { TOK_BYTE, $71, TOK_NUM_POKE, &$0300 } \
 		     emit { TOK_BYTE, $57, TOK_NUM_POKE, &$0302 } \
 		     emit { TOK_BYTE, $80, TOK_NUM_POKE, &$0303 } \

--- a/src/syntax/fujinet.syn
+++ b/src/syntax/fujinet.syn
@@ -1,0 +1,72 @@
+#
+# FastBasic - Fast basic interpreter for the Atari 8-bit computers
+# Copyright (C) 2017-2022 Daniel Serpell
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+#
+# FujiNet syntax additions by Thomas Cherryhomes
+# <thom dot cherryhomes at gmail dot com>
+#
+
+STATEMENT:
+        "NOpen" EXPR emit { TOK_NUM_POKE, &$301 } \
+	    "," EXPR emit { TOK_NUM_POKE, &$30A } \
+	    "," EXPR emit { TOK_NUM_POKE, &$30B } \
+	    ","      emit { TOK_NUM, &$304, TOK_SADDR } STR_EXPR emit { TOK_PUSH_1, TOK_ADD, TOK_DPOKE } \
+	             emit { TOK_BYTE, $71, TOK_NUM_POKE, &$300 } \
+		     emit { TOK_BYTE, $4F, TOK_NUM_POKE, &$302 } \
+		     emit { TOK_BYTE, $80, TOK_NUM_POKE, &$303 } \
+		     emit { TOK_BYTE, $1F, TOK_NUM_POKE, &$306 } \
+		     emit { TOK_NUM, &$308, TOK_SADDR, TOK_NUM, &$100, TOK_DPOKE } \
+	             emit { TOK_NUM, &$E459, TOK_USR_ADDR, TOK_USR_CALL }
+		   
+       "NClose" EXPR emit { TOK_NUM_POKE, &$301 } \
+	             emit { TOK_BYTE, $71, TOK_NUM_POKE, &$300 } \
+		     emit { TOK_BYTE, $43, TOK_NUM_POKE, &$302 } \
+		     emit { TOK_BYTE, $00, TOK_NUM_POKE, &$303 } \
+		     emit { TOK_BYTE, $1F, TOK_NUM_POKE, &$306 } \
+		     emit { TOK_NUM, &$308, TOK_SADDR, TOK_0, TOK_DPOKE } \
+	             emit { TOK_NUM, &$E459, TOK_USR_ADDR, TOK_USR_CALL }
+
+      "NStatus" EXPR emit { TOK_NUM_POKE, &$301 } \
+	             emit { TOK_BYTE, $71, TOK_NUM_POKE, &$300 } \
+		     emit { TOK_BYTE, $53, TOK_NUM_POKE, &$302 } \
+		     emit { TOK_BYTE, $40, TOK_NUM_POKE, &$303 } \
+		     emit { TOK_BYTE, $1F, TOK_NUM_POKE, &$306 } \
+      		     emit { TOK_NUM, &$304, TOK_SADDR, TOK_NUM, &$2EA, TOK_DPOKE } \
+		     emit { TOK_BYTE, $04, TOK_NUM_POKE, &$308 } \
+		     emit { TOK_BYTE, $00, TOK_NUM_POKE, &$309 } \
+	             emit { TOK_NUM, &$E459, TOK_USR_ADDR, TOK_USR_CALL }
+
+         "NGet" EXPR emit { TOK_NUM_POKE, &$301 } \
+	    ","      emit { TOK_NUM, &$304, TOK_SADDR } EXPR emit { TOK_DPOKE } \
+	    ","      emit { TOK_NUM, &$308, TOK_SADDR } EXPR emit { TOK_DPOKE } \
+	             emit { TOK_NUM, &$30A, TOK_SADDR TOK_NUM, &$308, TOK_DPEEK, TOK_DPOKE } \
+	             emit { TOK_BYTE, $71, TOK_NUM_POKE, &$0300 } \
+		     emit { TOK_BYTE, $52, TOK_NUM_POKE, &$0302 } \
+		     emit { TOK_BYTE, $40, TOK_NUM_POKE, &$0303 } \
+		     emit { TOK_BYTE, $1F, TOK_NUM_POKE, &$0306 } \
+	             emit { TOK_NUM, &$E459, TOK_USR_ADDR, TOK_USR_CALL }
+
+         "NPut" EXPR emit { TOK_NUM_POKE, &$301 } \
+	    ","      emit { TOK_NUM, &$304, TOK_SADDR } EXPR emit { TOK_DPOKE } \
+	    ","      emit { TOK_NUM, &$308, TOK_SADDR } EXPR emit { TOK_DPOKE } \
+	             emit { TOK_NUM, &$30A, TOK_SADDR TOK_NUM, &$308, TOK_DPEEK, TOK_DPOKE } \
+	             emit { TOK_BYTE, $71, TOK_NUM_POKE, &$0300 } \
+		     emit { TOK_BYTE, $57, TOK_NUM_POKE, &$0302 } \
+		     emit { TOK_BYTE, $80, TOK_NUM_POKE, &$0303 } \
+		     emit { TOK_BYTE, $1F, TOK_NUM_POKE, &$0306 } \
+	             emit { TOK_NUM, &$E459, TOK_USR_ADDR, TOK_USR_CALL }

--- a/src/syntax/sio.syn
+++ b/src/syntax/sio.syn
@@ -1,0 +1,32 @@
+#
+# FastBasic - Fast basic interpreter for the Atari 8-bit computers
+# Copyright (C) 2017-2022 Daniel Serpell
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+STATEMENT:
+        "SIo" EXPR emit { TOK_NUM_POKE, &$300 } \
+          "," EXPR  emit { TOK_NUM_POKE, &$301 } \
+          "," EXPR  emit { TOK_NUM_POKE, &$302 } \
+          "," EXPR  emit { TOK_NUM_POKE, &$303 } \
+          "," emit { TOK_NUM, &$304, TOK_SADDR } EXPR emit { TOK_DPOKE } \
+          "," EXPR  emit { TOK_NUM_POKE, &$306 } \
+          "," emit { TOK_NUM, &$308, TOK_SADDR } EXPR emit { TOK_DPOKE } \
+          "," EXPR  emit { TOK_NUM_POKE, &$30A } \
+          "," EXPR  emit { TOK_NUM_POKE, &$30B } \
+          emit { TOK_NUM, &$E459, TOK_USR_ADDR, TOK_USR_CALL }
+
+INT_FUNCTIONS:
+          "SErr()" emit { TOK_NUM, &$303, TOK_PEEK }


### PR DESCRIPTION
This PR adds FujiNet commands to FastBASIC.

NOPEN
NCLOSE
NGET, NPUT
NSTATUS

as well as accompanying documentation, and a test program, an implementation of netcat, nc.bas.