### PR TITLE
Fix build failure on Debian Linux.

### DIFF
--- a/src/compiler/atarifp.h
+++ b/src/compiler/atarifp.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <cmath>
 #include <string>
 


### PR DESCRIPTION
It appears that --- somehow --- atarifp.c isn't indirectly including stdint.h on my system, meaning that the uintX_t types aren't found. This causes the build to fail. This adds in the single missing line that fixes it on my system. This should hopefully not cause problems on other platforms.